### PR TITLE
security exception 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-/src/main/resources/application.yaml
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/example/webrtc/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/webrtc/common/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.example.webrtc.common.config;
 
+import static org.springframework.http.HttpMethod.*;
+
+import java.io.IOException;
 import java.util.Collections;
 
 import org.springframework.context.annotation.Bean;
@@ -21,6 +24,7 @@ import com.example.webrtc.common.filter.LoginFilter;
 import com.example.webrtc.common.service.CustomOAuth2UserService;
 import com.example.webrtc.common.utils.CustomSuccessHandler;
 import com.example.webrtc.common.utils.JWTUtil;
+import com.example.webrtc.common.utils.JwtAccessDeniedHandler;
 import com.example.webrtc.common.utils.JwtAuthenticationEntryPoint;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -35,6 +39,7 @@ public class SecurityConfig {
 	private final CustomSuccessHandler customSuccessHandler;
 	private final JWTUtil jwtUtil;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 	@Bean
 	public BCryptPasswordEncoder bCryptPasswordEncoder() {
 		return new BCryptPasswordEncoder();
@@ -78,6 +83,8 @@ public class SecurityConfig {
 		http
 			.exceptionHandling((exception) -> exception
 				.authenticationEntryPoint(jwtAuthenticationEntryPoint));
+				// .accessDeniedHandler(jwtAccessDeniedHandler));
+
 		//oath2
 		http
 			.oauth2Login((auth) -> auth
@@ -87,8 +94,8 @@ public class SecurityConfig {
 		//경로별 인가 작업
 		http
 			.authorizeHttpRequests((auth) -> auth
-				.requestMatchers( "/chatroom", "/websocket/**", "/").permitAll()
-				// .requestMatchers("/admin").hasRole("ADMIN")
+				.requestMatchers("/websocket/**").permitAll()
+				.requestMatchers(GET, "/chatroom").permitAll()
 				.anyRequest().authenticated());
 
 		//JWTFilter 등록

--- a/src/main/java/com/example/webrtc/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/webrtc/common/exception/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
 	CREDENTIALS_NOT_MATCHED_ERROR(401, "AUTH-001", "userName 또는 password가 일치하지 않습니다."),
 	ALREADY_EXIST_USER_ERROR(400, "AUTH-002", "이미 존재하는 사용자입니다."),
 	USERNAME_NOT_FOUND_ERROR(404, "AUTH-003", "사용자 이름을 찾을 수 없습니다."),
-	NOT_FOUND_USER_ERROR(404, "AUTH-004", "사용자를 찾을 수 없습니다."),;
+	NOT_FOUND_USER_ERROR(404, "AUTH-004", "사용자를 찾을 수 없습니다."),
+	ACCESS_DENIED_ERROR(403, "AUTH-005", "접근 권한이 없습니다."),;
 	// USERNAME_NOT_FOUND_ERROR(404, "AUTH-002", "사용자 이름을 찾을 수 엄습니다.");
 	// AUTHENTICATION_ERROR(401, "AUTH-003", "인증에 실패했습니다. 인증 수단이 유효한지 확인하세요."),
 	// AUTHORIZATION_ERROR(403, "AUTH-004", "권한이 존재하지 않습니다."),

--- a/src/main/java/com/example/webrtc/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/webrtc/common/exception/GlobalExceptionHandler.java
@@ -3,11 +3,7 @@ package com.example.webrtc.common.exception;
 import static java.time.LocalDateTime.*;
 import static org.springframework.http.HttpStatus.*;
 
-import java.security.SignatureException;
-
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -15,6 +11,8 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,8 +45,8 @@ public class GlobalExceptionHandler implements GlobalExceptionHandlerInterface{
 			.build();
 		return ResponseEntity.status(UNAUTHORIZED).body(response);
 	}
-	@ExceptionHandler(SignatureException.class)
-	public ResponseEntity<ErrorResponse> handleSignatureException(SignatureException e) {
+	@ExceptionHandler({SignatureException.class, MalformedJwtException.class, UnsupportedJwtException.class})
+	public ResponseEntity<ErrorResponse> handleSignatureException(Exception e) {
 		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
 		ErrorResponse response = ErrorResponse.builder()
 			.timeStamp(now())
@@ -59,16 +57,5 @@ public class GlobalExceptionHandler implements GlobalExceptionHandlerInterface{
 			.build();
 		return ResponseEntity.status(UNAUTHORIZED).body(response);
 	}
-	@ExceptionHandler(MissingRequestCookieException.class)
-	public ResponseEntity<ErrorResponse> handleMalformedJwtException(MissingRequestCookieException e) {
-		HttpServletRequest request = ((ServletRequestAttributes)RequestContextHolder.currentRequestAttributes()).getRequest();
-		ErrorResponse response = ErrorResponse.builder()
-			.timeStamp(now())
-			.status(ErrorCode.INVALID_TOKEN_ERROR.getStatus())
-			.error(ErrorCode.INVALID_TOKEN_ERROR.getCode())
-			.message(ErrorCode.INVALID_TOKEN_ERROR.getMessage())
-			.path(request.getRequestURI())
-			.build();
-		return ResponseEntity.status(UNAUTHORIZED).body(response);
-	}
+
 }

--- a/src/main/java/com/example/webrtc/common/utils/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/webrtc/common/utils/JwtAccessDeniedHandler.java
@@ -1,0 +1,26 @@
+package com.example.webrtc.common.utils;
+
+import java.io.IOException;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+	// TODO : 인가 도중 발생하는 exception에 대해서는 여기서 처리를 한다는데 왜 작동을 안하는지...?
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+		AccessDeniedException accessDeniedException) throws IOException, ServletException {
+		log.error("JwtAccessDeniedHandler 진입 = {}", accessDeniedException.getMessage());
+		response.sendError(HttpServletResponse.SC_FORBIDDEN, accessDeniedException.getMessage());
+	}
+}

--- a/src/main/java/com/example/webrtc/common/utils/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/webrtc/common/utils/JwtAuthenticationEntryPoint.java
@@ -1,5 +1,7 @@
 package com.example.webrtc.common.utils;
 
+import static com.example.webrtc.common.exception.ErrorCode.*;
+
 import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -7,6 +9,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import com.example.webrtc.common.exception.CustomException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -23,6 +27,9 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws
 		IOException {
+		if(request.getAttribute("exception") == null) {
+			request.setAttribute("exception", new CustomException(ACCESS_DENIED_ERROR));
+		}
 		log.error("JwtAuthenticationEntryPoint 진입 = {}", request.getAttribute("exception").getClass());
 		// JWTFilter에서 발생한 예외를 처리하기 위해 resolveException 메소드를 사용
 		resolver.resolveException(request, response, null, (Exception)request.getAttribute("exception"));

--- a/src/main/java/com/example/webrtc/common/utils/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/webrtc/common/utils/JwtAuthenticationEntryPoint.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
 	@Override
 	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws
 		IOException {
-		log.info("JwtAuthenticationEntryPoint 진입");
+		log.error("JwtAuthenticationEntryPoint 진입 = {}", request.getAttribute("exception").getClass());
 		// JWTFilter에서 발생한 예외를 처리하기 위해 resolveException 메소드를 사용
 		resolver.resolveException(request, response, null, (Exception)request.getAttribute("exception"));
 	}


### PR DESCRIPTION
기존의 exception은 처리가 잘되었지만 jwt token값이 null값일때는 권한이 필요한 요청일지라도 그냥 통과가 되었다. 디버깅을 통해서 AccessDeniedHandler에서 authenticationEntryPoint의 commence를 직접적으로 바로 호출하기 때문에 request단에서의 exception attribute가 존재하지 않았고 이로 인해 기존의 accessDeniedException 대신에 nullpointException이 발생해서 정상적으로 처리되지 않던 문제 해결